### PR TITLE
 AI Fix : Limitation of See_Invisible and Property Control Units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 XmlValidator.log
 desktop.ini
 Assets/Python/.idea/
+docs/
 
 # Ignore python venv
 env/

--- a/Assets/Config/Autolog.xml
+++ b/Assets/Config/Autolog.xml
@@ -10,10 +10,10 @@
 			<option id="Enabled" key="Enabled" type="boolean" default="True" get="isEnabled"/>
 			<option id="Silent" key="Silent" type="boolean" default="False" get="isSilent"/>
 
-			<list id="LogLevelPlayerBBAI" key="LogLevelPlayerBBAI" type="int" default="0" listType="int" values="0,1,2,3" get="getLogLevelPlayerBBAI"/>
-			<list id="LogLevelTeamBBAI" key="LogLevelTeamBBAI" type="int" default="0" listType="int" values="0,1,2,3" get="getLogLevelTeamBBAI"/>
-			<list id="LogLevelCityBBAI" key="LogLevelCityBBAI" type="int" default="0" listType="int" values="0,1,2,3" get="getLogLevelCityBBAI"/>
-			<list id="LogLevelUnitBBAI" key="LogLevelUnitBBAI" type="int" default="0" listType="int" values="0,1,2,3" get="getLogLevelUnitBBAI"/>
+			<list id="LogLevelPlayerBBAI" key="LogLevelPlayerBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelPlayerBBAI"/>
+			<list id="LogLevelTeamBBAI" key="LogLevelTeamBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelTeamBBAI"/>
+			<list id="LogLevelCityBBAI" key="LogLevelCityBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelCityBBAI"/>
+			<list id="LogLevelUnitBBAI" key="LogLevelUnitBBAI" type="int" default="0" listType="int" values="0,1,2,3,4" get="getLogLevelUnitBBAI"/>
 
 			<option id="MiscLogging" key="MiscLogging" type="boolean" default="True"/>
 

--- a/Assets/Python/Contrib/AutoSave.py
+++ b/Assets/Python/Contrib/AutoSave.py
@@ -1,14 +1,20 @@
 ## AutoSave
-from CvPythonExtensions import CyGlobalContext
+#from CvPythonExtensions import CyGlobalContext
+#from CvPythonExtensions import CyInterface
+from CvPythonExtensions import *
+import TextUtil
+
 GC = CyGlobalContext()
+CyIF = CyInterface()
 GAME = GC.getGame()
 MAP = GC.getMap()
+TRNSLTR = CyTranslator()
 import TextUtil
-        
+
 
 
 def remove_diacritics(in_text):
-    # Table des remplacements (caractËres + codes explicites)
+    # Table des remplacements (caract√®res + codes explicites)
     #print "Start remove_diacritics for %s" % in_text
     #print "%s" % str(type(in_text))
     text = u''
@@ -17,49 +23,70 @@ def remove_diacritics(in_text):
     except :
 		text = in_text.encode("ascii", "ignore")
     #print "%s" % text
-    text = text.replace('‡', 'a').replace('‚', 'a').replace('‰', 'a').replace('·', 'a').replace('„', 'a').replace('Â', 'a')
+    text = text.replace('√†', 'a').replace('√¢', 'a').replace('√§', 'a').replace('√°', 'a').replace('√£', 'a').replace('√•', 'a')
     #print "%s" % text
-    text = text.replace('Á', 'c')
-    text = text.replace('È', 'e').replace('Ë', 'e').replace('Í', 'e').replace('Î', 'e')
-    text = text.replace('Ó', 'i').replace('Ô', 'i').replace('Ì', 'i')
-    text = text.replace('Ù', 'o').replace('ˆ', 'o').replace('Ú', 'o').replace('Û', 'o').replace('ı', 'o')
-    text = text.replace('˘', 'u').replace('˚', 'u').replace('¸', 'u').replace('˙', 'u')
-    text = text.replace('ˇ', 'y')
-    text = text.replace('Ò', 'n')
+    text = text.replace('√ß', 'c')
+    text = text.replace('√©', 'e').replace('√®', 'e').replace('√™', 'e').replace('√´', 'e')
+    text = text.replace('√Æ', 'i').replace('√Ø', 'i').replace('√≠', 'i')
+    text = text.replace('√¥', 'o').replace('√∂', 'o').replace('√≤', 'o').replace('√≥', 'o').replace('√µ', 'o')
+    text = text.replace('√π', 'u').replace('√ª', 'u').replace('√º', 'u').replace('√∫', 'u')
+    text = text.replace('√ø', 'y')
+    text = text.replace('√±', 'n')
 
-    text = text.replace('¿', 'A').replace('¬', 'A').replace('ƒ', 'A').replace('¡', 'A').replace('√', 'A').replace('≈', 'A')
-    text = text.replace('«', 'C')
-    text = text.replace('…', 'E').replace('»', 'E').replace(' ', 'E').replace('À', 'E')
-    text = text.replace('Œ', 'I').replace('œ', 'I').replace('Õ', 'I')
-    text = text.replace('‘', 'O').replace('÷', 'O').replace('“', 'O').replace('”', 'O').replace('’', 'O')
-    text = text.replace('Ÿ', 'U').replace('€', 'U').replace('‹', 'U').replace('⁄', 'U')
-    text = text.replace('ü', 'Y')
-    text = text.replace('—', 'N')
+    text = text.replace('√Ä', 'A').replace('√Ç', 'A').replace('√Ñ', 'A').replace('√Å', 'A').replace('√É', 'A').replace('√Ö', 'A')
+    text = text.replace('√á', 'C')
+    text = text.replace('√â', 'E').replace('√à', 'E').replace('√ä', 'E').replace('√ã', 'E')
+    text = text.replace('√é', 'I').replace('√è', 'I').replace('√ç', 'I')
+    text = text.replace('√î', 'O').replace('√ñ', 'O').replace('√í', 'O').replace('√ì', 'O').replace('√ï', 'O')
+    text = text.replace('√ô', 'U').replace('√õ', 'U').replace('√ú', 'U').replace('√ö', 'U')
+    text = text.replace('≈∏', 'Y')
+    text = text.replace('√ë', 'N')
 
     #print "%s" % text
     return text
         
 def cleanNpc():
-	print "Cleaning NPC - for player 41 and 42..."
-	iPlayer = 41
-	pPlayer = GC.getPlayer(iPlayer)
-	pUnit, loop = pPlayer.firstUnit(False)
-	while pUnit:
-		pUnit
-		print "Player %d, Unit ID: %d, %s\n" % (iPlayer, pUnit.getID(), TextUtil.convertToStr(pUnit.getName()))
-		pUnit.kill(False, -1)
-		pUnit, loop = pPlayer.nextUnit(loop, False)
-	print "UnitÈs du joueur 41 supprimÈes."
-	
-	iPlayer = 42
-	pPlayer = GC.getPlayer(iPlayer)
-	pUnit, loop = pPlayer.firstUnit(False)
-	while pUnit:
-		pUnit
-		print "Player %d, Unit ID: %d, %s\n" % (iPlayer, pUnit.getID(), TextUtil.convertToStr(pUnit.getName()))
-		pUnit.kill(False, -1)
-		pUnit, loop = pPlayer.nextUnit(loop, False)
-	print "UnitÈs du joueur 42 supprimÈes."
+	iTurn = GAME.getGameTurn()
+	modturn = iTurn % 30
+	print "ModTurn for cleaning : %d" % modturn
+	if npcclean and modturn == 0:
+		print "Cleaning NPC - for player 40,41 and 42..."
+
+		iPlayer = 40
+		pPlayer = GC.getPlayer(iPlayer)
+		pUnit, loop = pPlayer.firstUnit(False)
+		while pUnit:
+			pUnit
+			print "Player %d, Unit ID: %d, %s\n" % (iPlayer, pUnit.getID(), TextUtil.convertToStr(pUnit.getName()))
+			pUnit.kill(False, -1)
+			pUnit, loop = pPlayer.nextUnit(loop, False)
+		print "Unit√©s du joueur 40 supprim√©es."
+
+		iPlayer = 41
+		pPlayer = GC.getPlayer(iPlayer)
+		pUnit, loop = pPlayer.firstUnit(False)
+		while pUnit:
+			pUnit
+			print "Player %d, Unit ID: %d, %s\n" % (iPlayer, pUnit.getID(), TextUtil.convertToStr(pUnit.getName()))
+			pUnit.kill(False, -1)
+			pUnit, loop = pPlayer.nextUnit(loop, False)
+		print "Unit√©s du joueur 41 supprim√©es."
+		
+		iPlayer = 42
+		pPlayer = GC.getPlayer(iPlayer)
+		pUnit, loop = pPlayer.firstUnit(False)
+		while pUnit:
+			pUnit
+			print "Player %d, Unit ID: %d, %s\n" % (iPlayer, pUnit.getID(), TextUtil.convertToStr(pUnit.getName()))
+			pUnit.kill(False, -1)
+			pUnit, loop = pPlayer.nextUnit(loop, False)
+		print "Unit√©s du joueur 42 supprim√©es."
+		szMessage = TRNSLTR.getText("TXT_KEY_MOD_KILL_ANIMALS_DESC", ())
+		for iPlayer in range(GC.getMAX_PLAYERS()):
+			if GC.getPlayer(iPlayer).isHuman():
+				CyIF.addMessage(iPlayer, False, GC.getEVENT_MESSAGE_TIME(), szMessage, None, InterfaceMessageTypes.MESSAGE_TYPE_INFO, None, GC.getInfoTypeForString("COLOR_HIGHLIGHT_TEXT"), -1, -1, False, False)
+
+
 def init():
 	import SystemPaths as SP
 	global _saveDir, options

--- a/Assets/Python/Contrib/EventSigns.py
+++ b/Assets/Python/Contrib/EventSigns.py
@@ -67,8 +67,11 @@ def addSign(pPlot, ePlayer, szCaption):
 
 	Fix by God-Emperor
 	"""
-	if not pPlot or pPlot.getX() == -1 or pPlot.getY() == -1:
-		BugUtil.warn("EventSigns.addSign() was passed an invalid plot")
+	if not pPlot :
+		BugUtil.warn("EventSigns.addSign() was passed an invalid plot for caption : %s" % szCaption)
+		return False
+	if pPlot.getX() == -1 or pPlot.getY() == -1:
+		BugUtil.warn("EventSigns.addSign() was passed an plot with -1 coords for caption : %s" % szCaption)
 		return False
 	if gSavedSigns == None:
 		BugUtil.warn("EventSigns.addSign() gSavedSigns is not initialized!")

--- a/Assets/Python/ScreenInput.py
+++ b/Assets/Python/ScreenInput.py
@@ -6,6 +6,8 @@ class ScreenInput:
 
 	# Init call...
 	def __init__ (self, argsList):
+		if len(argsList) < 15:
+			raise ValueError("argsList must contain at least 15 elements")
 		self.eNotifyCode = argsList[0]
 		self.iData = argsList[1]
 		self.uiFlags = argsList[2]
@@ -81,4 +83,3 @@ class ScreenInput:
 	# Widget Option
 	def getOption (self):
 		return self.bOption
-

--- a/Assets/Python/pyWB/CvWBDesc.py
+++ b/Assets/Python/pyWB/CvWBDesc.py
@@ -1795,7 +1795,7 @@ class CvSignDesc:
 			CyEngine().addSign(pPlot, self.playerType, self.szCaption)
 		print "sign added at %dx%dy for player %d with caption: '%s'" %(self.iX, self.iY, self.playerType, self.szCaption)
 		else:
-			print "?? Plot invalide : x = %d, y = %d" % (x, y)		
+			print "Plot invalide : x = %d, y = %d" % (x, y)		
 
 # handles saving/loading a worldbuilder description file
 class CvWBDesc:

--- a/Assets/Python/pyWB/CvWBDesc.py
+++ b/Assets/Python/pyWB/CvWBDesc.py
@@ -1793,7 +1793,7 @@ class CvSignDesc:
 		pPlot = GC.getMap().plot(self.iX, self.iY)
 		if pPlot and not pPlot.isNone():
 			CyEngine().addSign(pPlot, self.playerType, self.szCaption)
-		print "sign added at %dx%dy for player %d with caption: '%s'" %(self.iX, self.iY, self.playerType, self.szCaption)
+			print "sign added at %dx%dy for player %d with caption: '%s'" %(self.iX, self.iY, self.playerType, self.szCaption)
 		else:
 			print "Plot invalide : x = %d, y = %d" % (x, y)		
 

--- a/Assets/XML/A_New_Dawn_GlobalDefines.xml
+++ b/Assets/XML/A_New_Dawn_GlobalDefines.xml
@@ -307,6 +307,6 @@ The Great Wall is always dynamic if viewports are enabled regardless of this set
 	</Define>
 	<Define>
 		<DefineName>C2C_VERSION</DefineName>
-		<DefineTextVal>v45FR.BETA</DefineTextVal>
+		<DefineTextVal>v45.BETA</DefineTextVal>
 	</Define>
 </Civ4Defines>

--- a/Assets/XML/Buildings/zAnimals_CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/zAnimals_CIV4BuildingInfos.xml
@@ -1274,6 +1274,9 @@
 			<PrereqOrHeritage>
 				<Type>HERITAGE_TAXON_SUIDAE</Type>
 				<Type>HERITAGE_TAXON_ELEPHANTIDAE</Type>
+				<Type>HERITAGE_TAXON_TAPIRIDAE</Type>	
+				<Type>HERITAGE_TAXON_HIPPOPOTAMIDAE</Type>	
+				<Type>HERITAGE_TAXON_MONOTREMATA</Type>	
 			</PrereqOrHeritage>
 			<ConstructCondition>
 				<Or>
@@ -1288,6 +1291,10 @@
 					<Has>
 						<GOMType>GOM_BUILDING</GOMType>
 						<ID>BUILDING_FOLKLORE_T_RHINOCEROSES</ID>
+					</Has>
+					<Has>
+						<GOMType>GOM_BUILDING</GOMType>
+						<ID>BUILDING_FOLKLORE_T_BULL</ID>
 					</Has>
 				</Or>
 			</ConstructCondition>
@@ -2619,13 +2626,34 @@
 			<Advisor>ADVISOR_CULTURE</Advisor>
 			<ArtDefineTag>ART_DEF_BUILDING_ENCLOSURE_PRIMATE</ArtDefineTag>
 			<PrereqTech>TECH_TRADE</PrereqTech>
-			<PrereqOrBuildings>
-				<BuildingType>BUILDING_CARNIVAL</BuildingType>
-				<BuildingType>BUILDING_ZOO</BuildingType>
-			</PrereqOrBuildings>
-			<PrereqInCityBuildings>
-				<BuildingType>BUILDING_FOLKLORE_T_OLD_MAN_OF_THE_FOREST</BuildingType>
-			</PrereqInCityBuildings>
+			<ConstructCondition>
+				<And>
+					<Or>
+						<Has>
+							<GOMType>GOM_BUILDING</GOMType>
+							<ID>BUILDING_CARNIVAL</ID>
+						</Has>
+						<Has>
+							<GOMType>GOM_BUILDING</GOMType>
+							<ID>BUILDING_ZOO</ID>
+						</Has>
+					</Or>
+					<Or>
+						<Has>
+							<GOMType>GOM_BUILDING</GOMType>
+							<ID>BUILDING_FOLKLORE_T_OLD_MAN_OF_THE_FOREST</ID>
+						</Has>
+						<Has>
+							<GOMType>GOM_BUILDING</GOMType>
+							<ID>BUILDING_FOLKLORE_T_OLD_WORLD_MONKEYS</ID>
+						</Has>
+						<Has>
+							<GOMType>GOM_BUILDING</GOMType>
+							<ID>BUILDING_FOLKLORE_T_NEW_WORLD_MONKEYS</ID>
+						</Has>
+					</Or>
+				</And>
+			</ConstructCondition>
 			<iCost>306</iCost>
 			<iCostSizeModifier>1</iCostSizeModifier>
 			<iCostCountModifier>0</iCostCountModifier>

--- a/Assets/XML/Civilizations/HeritageInfos.xml
+++ b/Assets/XML/Civilizations/HeritageInfos.xml
@@ -5427,6 +5427,7 @@
 				<Type>HERITAGE_FOLKLORE_LION_CAVE</Type>
 				<Type>HERITAGE_FOLKLORE_TIGER_BENGAL</Type>
 				<Type>HERITAGE_FOLKLORE_TIGER_SIBERIAN</Type>
+				<Type>HERITAGE_FOLKLORE_LYNX</Type>
 			</PrereqOrHeritage>
 			<EraCommerceChanges>
 				<EraCommerceChange>

--- a/Assets/XML/Units/CIV4PromotionInfos.xml
+++ b/Assets/XML/Units/CIV4PromotionInfos.xml
@@ -12240,6 +12240,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_INCAPABLE</ReplacesUnitCombat>
 			<bZeroesXP>1</bZeroesXP>
@@ -12261,6 +12262,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>1</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_PATHETIC</ReplacesUnitCombat>
@@ -12283,6 +12285,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>2</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_INFERIOR</ReplacesUnitCombat>
@@ -12305,6 +12308,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>3</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_POOR</ReplacesUnitCombat>
@@ -12349,6 +12353,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>6</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_STANDARD</ReplacesUnitCombat>
@@ -12371,6 +12376,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>8</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_SUPERIOR</ReplacesUnitCombat>
@@ -12393,6 +12399,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>11</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_EXCEPTIONAL</ReplacesUnitCombat>
@@ -12415,6 +12422,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>15</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_ELITE</ReplacesUnitCombat>
@@ -12437,6 +12445,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<iLevelPrereq>20</iLevelPrereq>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_EPIC</ReplacesUnitCombat>
@@ -12459,6 +12468,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_DIVINE</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12480,6 +12490,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_EPIC</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12501,6 +12512,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_ELITE</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12522,6 +12534,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_EXCEPTIONAL</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12543,6 +12556,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_SUPERIOR</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12564,6 +12578,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_STANDARD</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12585,6 +12600,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_MEDIOCRE</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12606,6 +12622,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_POOR</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12627,6 +12644,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_INFERIOR</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -12648,6 +12666,7 @@
 			</OnGameOptions>
 			<NotOnUnitCombatTypes>
 				<NotOnUnitCombatType>UNITCOMBAT_PACIFIST</NotOnUnitCombatType>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
 			</NotOnUnitCombatTypes>
 			<ReplacesUnitCombat>UNITCOMBAT_QUALITY_PATHETIC</ReplacesUnitCombat>
 			<bForOffset>1</bForOffset>
@@ -15384,6 +15403,9 @@
 			<iLinePriority>1</iLinePriority>
 			<iUpkeepModifier>5</iUpkeepModifier>
 			<iStrengthChange>1</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_INFERIOR</UnitCombatType>
@@ -15434,6 +15456,9 @@
 			<iLevelPrereq>5</iLevelPrereq>
 			<iUpkeepModifier>5</iUpkeepModifier>
 			<iStrengthChange>1</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_POOR</UnitCombatType>
@@ -15480,6 +15505,9 @@
 			<iLevelPrereq>7</iLevelPrereq>
 			<iUpkeepModifier>5</iUpkeepModifier>
 			<iStrengthChange>2</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_MEDIOCRE</UnitCombatType>
@@ -15522,6 +15550,9 @@
 			<iLevelPrereq>9</iLevelPrereq>
 			<iUpkeepModifier>5</iUpkeepModifier>
 			<iStrengthChange>2</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_STANDARD</UnitCombatType>
@@ -15560,6 +15591,9 @@
 			<iLevelPrereq>11</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>3</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_SUPERIOR</UnitCombatType>
@@ -15594,6 +15628,9 @@
 			<iLevelPrereq>13</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>4</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_SUPERIOR</UnitCombatType>
@@ -15628,6 +15665,9 @@
 			<iLevelPrereq>15</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>5</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_EXCEPTIONAL</UnitCombatType>
@@ -15658,6 +15698,9 @@
 			<iLevelPrereq>17</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>7</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_EXCEPTIONAL</UnitCombatType>
@@ -15688,6 +15731,9 @@
 			<iLevelPrereq>19</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>10</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_ELITE</UnitCombatType>
@@ -15714,6 +15760,9 @@
 			<iLevelPrereq>21</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>15</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_ELITE</UnitCombatType>
@@ -15740,6 +15789,9 @@
 			<iLevelPrereq>23</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>20</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_EPIC</UnitCombatType>
@@ -15762,6 +15814,9 @@
 			<iLevelPrereq>25</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>25</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_EPIC</UnitCombatType>
@@ -15784,6 +15839,9 @@
 			<iLevelPrereq>27</iLevelPrereq>
 			<iUpkeepModifier>10</iUpkeepModifier>
 			<iStrengthChange>30</iStrengthChange>
+			<NotOnUnitCombatTypes>
+				<NotOnUnitCombatType>UNITCOMBAT_ANIMAL</NotOnUnitCombatType>
+			</NotOnUnitCombatTypes>
 			<UnitCombats>
 				<UnitCombat>
 					<UnitCombatType>UNITCOMBAT_QUALITY_DIVINE</UnitCombatType>

--- a/Sources/BetterBTSAI.cpp
+++ b/Sources/BetterBTSAI.cpp
@@ -6,6 +6,7 @@
 // 1 - Important decisions only
 // 2 - Many decisions
 // 3 - All logging
+// 4 - All logging with very often trace (unit/promotion eval)
 int gPlayerLogLevel = 0;
 int gTeamLogLevel = 0;
 int gCityLogLevel = 0;

--- a/Sources/C2C (VS2019).vcxproj
+++ b/Sources/C2C (VS2019).vcxproj
@@ -238,6 +238,7 @@
     <ClCompile Include="CvSettlerAI.cpp" />
     <ClCompile Include="CvTraitInfo.cpp" />
     <ClCompile Include="CvUnitCombatInfo.cpp" />
+    <ClCompile Include="CvUnitSelectionCriteria.cpp" />
     <ClCompile Include="CvValueService.cpp" />
     <ClCompile Include="CvWorkerAI.cpp" />
     <ClCompile Include="CvWorkerService.cpp" />

--- a/Sources/C2C (VS2019).vcxproj.filters
+++ b/Sources/C2C (VS2019).vcxproj.filters
@@ -756,6 +756,9 @@
     <ClCompile Include="CvHallOfFameInfo.cpp">
       <Filter>Source\Base\Infos</Filter>
     </ClCompile>
+    <ClCompile Include="CvUnitSelectionCriteria.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CvDLLButtonPopup.h">

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -15413,9 +15413,9 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 				setUnitListInvalid();
 				if (gCityLogLevel >= 1)
 				{
-					CvWString szString;
-					getUnitAIString(szString, order.getUnitAIType());
-					logBBAI("    City %S pushes production of unit %S for type UNITAI_%S", getName().GetCString(), GC.getUnitInfo(unitType).getDescription(getCivilizationType()), szString.GetCString());
+					
+					const CvWString szStringUnitAi = GC.getUnitAIInfo(order.getUnitAIType()).getType();
+					logBBAI("    City %S pushes production of unit %S for type %S", getName().GetCString(), GC.getUnitInfo(unitType).getDescription(getCivilizationType()), szStringUnitAi.GetCString());
 				}
 				bValid = true;
 			}
@@ -15716,9 +15716,8 @@ void CvCity::popOrder(int orderIndex, bool bFinish, bool bChoose, bool bResolveL
 				{
 					if (gCityLogLevel >= 1)
 					{
-						CvWString szString;
-						getUnitAIString(szString, pUnit->AI_getUnitAIType());
-						logBBAI("    City %S finishes production of unit %S with UNITAI %S", getName().GetCString(), pUnit->getName(0).GetCString(), szString.GetCString());
+						const CvWString szStringUnitAi = GC.getUnitAIInfo(pUnit->AI_getUnitAIType()).getType();
+						logBBAI("    City %S finishes production of unit %S for Type %S", getName().GetCString(), pUnit->getName(0).GetCString(), szStringUnitAi.GetCString());
 					}
 
 					if (GC.getUnitInfo(eTrainUnit).getDomainType() == DOMAIN_AIR)

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -16368,7 +16368,7 @@ void CvCity::doProduction(bool bAllowNoProduction)
 				}
 				else AI_chooseProduction();
 
-				FAssertMsg(isProduction(), "AI set city to pruduce nothing at all!")
+				FAssertMsg(isProduction(), "AI set city to produce nothing at all!")
 			}
 
 			/* Toffer - Don't think the wonder limit can be breached here just like that.

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -3743,6 +3743,9 @@ UnitTypes CvCityAI::AI_bestUnit(int& iBestUnitValue, int iNumSelectableTypes, Un
 
 	int iBestValue = 0;
 	UnitTypes eBestUnit = NO_UNIT;
+	CvWString strUnitAIType;
+	CvWString strUnitAITypeWeight;
+	CvWString strUnitType;
 
 	for (int iI = 0; iI < NUM_UNITAI_TYPES; iI++)
 	{
@@ -3779,6 +3782,21 @@ UnitTypes CvCityAI::AI_bestUnit(int& iBestUnitValue, int iNumSelectableTypes, Un
 				if (aiUnitAIVal[iI] < iBestValue)
 				{
 					bValid = false;
+					//TODOLogLevel
+					if (gCityLogLevel > 3)
+					{
+						strUnitAITypeWeight = GC.getUnitAIInfo((UnitAITypes)iI).getType();
+						logAiEvaluations(2, "City %S, lower prio for UnitAI %S, skipping, UnitAI value %d, best UnitAI value %d", getName().GetCString(), strUnitAIType.c_str(), strUnitType.c_str(), aiUnitAIVal[iI], iBestValue);
+					}
+				}
+				else
+				{
+					//TODOLogLevel
+					if (gCityLogLevel > 3)
+					{
+						strUnitAITypeWeight = GC.getUnitAIInfo((UnitAITypes)iI).getType();
+						logAiEvaluations(2, "City %S, AiWeight for UnitAI %S is valid, UnitAI value %d, best last UnitAI value %d", getName().GetCString(), strUnitAIType.c_str(), strUnitType.c_str(), aiUnitAIVal[iI], iBestValue);
+					}
 				}
 			}
 
@@ -3796,18 +3814,36 @@ UnitTypes CvCityAI::AI_bestUnit(int& iBestUnitValue, int iNumSelectableTypes, Un
 					if (peBestUnitAI != NULL)
 					{
 						*peBestUnitAI = ((UnitAITypes)iI);
-						//TODOLogLevel
-						if (gCityLogLevel > 2)
-						{
-							const CvWString strUnitType = GC.getUnitInfo(eUnit).getType();
-							const CvWString strUnitAIType = GC.getUnitAIInfo((UnitAITypes)iI).getType();
-							logAiEvaluations(2, "City %S, Better AI Unit chosen for %S, type %S, %S, unit final value %d, best value %d", getName().GetCString(), strUnitAIType.c_str(), strUnitType.c_str(), GC.getUnitInfo(eUnit).getDescription(), iUnitValue, iBestValue);
-						}
-
 					}
+					//TODOLogLevel
+					if (gCityLogLevel > 2)
+					{
+						strUnitType = GC.getUnitInfo(eUnit).getType();
+						strUnitAIType = GC.getUnitAIInfo((UnitAITypes)iI).getType();
+						logAiEvaluations(2, "City %S, Better AI Unit chosen for %S, type %S, %S, unit final value %d, best value %d", getName().GetCString(), strUnitAIType.c_str(), strUnitType.c_str(), GC.getUnitInfo(eUnit).getDescription(), iUnitValue, iBestValue);
+					}
+					
 					iBestUnitValue = iUnitValue;
 				}
 			}
+		}
+	}
+	//TODOLogLevel
+	if (gCityLogLevel > 2)
+	{
+		CvWString strCriteria = "None";
+		if (criteria != NULL)
+		{
+			strCriteria = criteria->getDescription();
+		}
+		if (eBestUnit == NO_UNIT)
+		{
+
+			logAiEvaluations(2, "City %S, At the End, No Unit found that meet criteria (%S) in All UNITAI List.", getName().GetCString(), strCriteria.GetCString());
+		}
+		else
+		{
+			logAiEvaluations(2, "City %S, At the End, Unit chosen for %S and criteria (%S), type %S, %S, with value %d", getName().GetCString(), strUnitAIType.c_str(), strCriteria.GetCString(), strUnitType.c_str(), GC.getUnitInfo(eBestUnit).getDescription(), iBestValue);
 		}
 	}
 
@@ -3825,12 +3861,20 @@ UnitTypes CvCityAI::AI_bestUnitAI(UnitAITypes eUnitAI, int& iBestValue, bool bAs
 	{
 		const CvWString strUnitType = GC.getUnitAIInfo(eUnitAI).getType();
 		CvWString strCriteria = "None";
+		bool display = true;
 		if (criteria != NULL)
 		{
 			strCriteria = criteria->getDescription();
+			if (criteria->m_bIgnoreGrowth)
+			{
+				display = false;
+				logAiEvaluations(4, "City %S, AI_bestUnitAI searching for %S ... - criteria %S - to evaluate Danger", getName().GetCString(), strUnitType.c_str(), strCriteria.GetCString());
+			}
 		}
-		
-		logAiEvaluations(2, "City %S, AI_bestUnitAI searching for %S ... - criteria %S", getName().GetCString(), strUnitType.c_str() , strCriteria.GetCString());
+		if (display)
+		{
+			logAiEvaluations(2, "City %S, AI_bestUnitAI searching for %S ... - criteria %S", getName().GetCString(), strUnitType.c_str(), strCriteria.GetCString());
+		}
 	}
 
 
@@ -3882,7 +3926,7 @@ UnitTypes CvCityAI::AI_bestUnitAI(UnitAITypes eUnitAI, int& iBestValue, bool bAs
 			iBestValue = itr->second.iValue;
 			eBestUnit = itr->second.eUnit;
 
-			if (gCityLogLevel > 3) //deactivate
+			if (gCityLogLevel > 3) //add a Level4 Trace Logs
 			{
 				const CvWString strUnitType = GC.getUnitInfo(eBestUnit).getType();
 				const CvWString strUnitAIType = GC.getUnitAIInfo(eUnitAI).getType();
@@ -4003,11 +4047,24 @@ UnitTypes CvCityAI::AI_bestUnitAI(UnitAITypes eUnitAI, int& iBestValue, bool bAs
 				iBestValue = iValue;
 				eBestUnit = eUnitX;
 
-				if (gCityLogLevel > 2)
+				if (gCityLogLevel > 3)
 				{
 					const CvWString strUnitType = GC.getUnitInfo(eUnitX).getType();
 					const CvWString strUnitAIType = GC.getUnitAIInfo(eUnitAI).getType();
-					logAiEvaluations(2, "City %S, Better AI Unit found for %S, type %S, %S, base value %d, final value %d", getName().GetCString(), strUnitAIType.c_str(), strUnitType.c_str(), GC.getUnitInfo(eUnitX).getDescription(), iBaseValue*100, iValue);
+					CvWString strCriteria = "None";
+					bool display = true;
+					if (criteria != NULL)
+					{
+						strCriteria = criteria->getDescription();
+						if (criteria->m_bIgnoreGrowth)
+						{
+							display = false;
+						}
+					}
+					if (display)
+					{
+						logAiEvaluations(2, "City %S, Better AI Unit found for %S and criteria %S, type %S, %S, base value %d, final value %d", getName().GetCString(), strUnitAIType.c_str(), strCriteria.GetCString(), strUnitType.c_str(), GC.getUnitInfo(eUnitX).getDescription(), iBaseValue * 100, iValue);
+					}
 				}
 
 
@@ -14823,7 +14880,11 @@ bool CvCityAI::AI_establishSeeInvisibleCoverage()
 					logAiEvaluations(2, "City %S, Not enough 'UNITAI_SEE_INVISIBLE' (for visibility : %S) here : responders %d, active %d", getName().GetCString(), szDesc.GetCString(), iResponders, iActiveResponders);
 				}
 				//end result
-				if (AI_chooseUnit("See Invisible needed", UNITAI_SEE_INVISIBLE, -1, -1, -1, &criteria))
+
+				//Calvitix Test. demand an See Invisible only in 20% of cases
+				int irandomaction = GC.getGame().getSorenRandNum(10, "AI See Invisible Invoqued");
+
+				if (irandomaction > 7 && AI_chooseUnit("See Invisible needed", UNITAI_SEE_INVISIBLE, -1, -1, -1, &criteria))
 				{
 					if (gCityLogLevel > 2)
 					{
@@ -14833,6 +14894,17 @@ bool CvCityAI::AI_establishSeeInvisibleCoverage()
 					}
 					return true;
 				}
+				else if (irandomaction <= 7)
+				{
+					if (gCityLogLevel > 2)
+					{
+						CvWString szDesc = GC.getInvisibleInfo(eVisible).getDescription();
+						CvWString szDesccriteria = criteria.getDescription();
+						logAiEvaluations(2, "City %S, Unit for 'UNITAI_SEE_INVISIBLE' (for visibility : %S) , criteria : %S, needed, but random fail.", getName().GetCString(), szDesc.GetCString(), szDesccriteria.GetCString());
+					}
+
+				}
+
 			}
 			else
 			{

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -9740,7 +9740,7 @@ void CvGame::changeHighToLowCounter(int iChange)
 void CvGame::doFinalFive()
 {
 	PROFILE_EXTRA_FUNC();
-	if (!isGameMultiPlayer() && isOption(GAMEOPTION_CHALLENGE_CUT_LOSERS) && countCivPlayersAlive() > 5)
+	if (!isGameMultiPlayer() && isOption(GAMEOPTION_CHALLENGE_CUT_LOSERS) && countCivPlayersAlive() > 12)
 	{
 		changeCutLosersCounter(1);
 		if (getCutLosersCounter() >= GC.getDefineINT("CUT_LOSERS_TURN_INCREMENT") * GC.getGameSpeedInfo(getGameSpeedType()).getSpeedPercent() / 100)

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -9740,7 +9740,7 @@ void CvGame::changeHighToLowCounter(int iChange)
 void CvGame::doFinalFive()
 {
 	PROFILE_EXTRA_FUNC();
-	if (!isGameMultiPlayer() && isOption(GAMEOPTION_CHALLENGE_CUT_LOSERS) && countCivPlayersAlive() > 10) //Calvitix TODO restore to 5
+	if (!isGameMultiPlayer() && isOption(GAMEOPTION_CHALLENGE_CUT_LOSERS) && countCivPlayersAlive() > 5)
 	{
 		changeCutLosersCounter(1);
 		if (getCutLosersCounter() >= GC.getDefineINT("CUT_LOSERS_TURN_INCREMENT") * GC.getGameSpeedInfo(getGameSpeedType()).getSpeedPercent() / 100)

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -9740,7 +9740,7 @@ void CvGame::changeHighToLowCounter(int iChange)
 void CvGame::doFinalFive()
 {
 	PROFILE_EXTRA_FUNC();
-	if (!isGameMultiPlayer() && isOption(GAMEOPTION_CHALLENGE_CUT_LOSERS) && countCivPlayersAlive() > 12)
+	if (!isGameMultiPlayer() && isOption(GAMEOPTION_CHALLENGE_CUT_LOSERS) && countCivPlayersAlive() > 10) //Calvitix TODO restore to 5
 	{
 		changeCutLosersCounter(1);
 		if (getCutLosersCounter() >= GC.getDefineINT("CUT_LOSERS_TURN_INCREMENT") * GC.getGameSpeedInfo(getGameSpeedType()).getSpeedPercent() / 100)

--- a/Sources/CvGlobals.cpp
+++ b/Sources/CvGlobals.cpp
@@ -3024,6 +3024,15 @@ void cvInternalGlobals::refreshOptionsBUG()
 	gUnitLogLevel = getBugOptionINT("Autolog__LogLevelUnitBBAI", 0);
 	gMiscLogging = getBugOptionBOOL("Autolog__MiscLogging", false);
 
+#ifdef _DEBUG
+	gPlayerLogLevel = 4;
+	gTeamLogLevel = 4;
+	gCityLogLevel = 4;
+	gUnitLogLevel = 4;
+#endif // DEBUG
+
+
+
 	OutputRatios::setBaseOutputWeights(
 		getBugOptionINT("CityScreen__BaseWeightFood", 10),
 		getBugOptionINT("CityScreen__BaseWeightHammer", 8),

--- a/Sources/CvGlobals.cpp
+++ b/Sources/CvGlobals.cpp
@@ -1436,6 +1436,8 @@ CvInfoBase& cvInternalGlobals::getUnitAIInfo(UnitAITypes eUnitAINum) const
 	FASSERT_BOUNDS(0, NUM_UNITAI_TYPES, eUnitAINum);
 	return *(m_paUnitAIInfos[eUnitAINum]);
 }
+
+
 void cvInternalGlobals::registerUnitAI(const char* szType, int enumVal)
 {
 	FAssertMsg(m_paUnitAIInfos.size() == enumVal, "enumVal not expected value");
@@ -1445,6 +1447,9 @@ void cvInternalGlobals::registerUnitAI(const char* szType, int enumVal)
 	m_paUnitAIInfos.push_back(entry);
 	setInfoTypeFromString(szType, enumVal);
 }
+
+
+
 
 #define	REGISTER_UNITAI(x)	registerUnitAI(#x,x)
 

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -3135,10 +3135,8 @@ void CvPlayer::disbandUnit()
 
 		if( gPlayerLogLevel >= 2 )
 		{
-			CvWString szString;
-			getUnitAIString(szString, pBestUnit->AI_getUnitAIType());
-
-			logBBAI("	Player %d (%S) disbanding %S with UNITAI %S (forced)", getID(), getCivilizationDescription(0), pBestUnit->getName().GetCString(), szString.GetCString());
+			const CvWString szStringUnitAi = GC.getUnitAIInfo(pBestUnit->AI_getUnitAIType()).getType();
+			logBBAI("	Player %d (%S) disbanding %S with UNITAI %S (forced)", getID(), getCivilizationDescription(0), pBestUnit->getName().GetCString(), szStringUnitAi.GetCString());
 		}
 
 		pBestUnit->kill(false);

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -10263,10 +10263,10 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 	bool bisPositivePropertyUnit = (iGeneralPropertyValue > 0);
 	bool bUndefinedValid = false, bValid = false;
 
-	if (eUnitAI != UNITAI_PROPERTY_CONTROL && bisPositivePropertyUnit)
-	{
-		return 0;
-	}
+	//if (eUnitAI != UNITAI_PROPERTY_CONTROL && eUnitAI != UNITAI_SEE_INVISIBLE && bisPositivePropertyUnit)
+	//{
+	//	return 0;
+	//}
 
 	switch (eUnitAI)
 	{
@@ -11330,7 +11330,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			{
 				//Calvitix try to limit impact of moves
 				iValue += iCombatValue;
-				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) * 0.50;
+				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) / 2;
 				//iValue += iCombatValue * kUnitInfo.getMoves();
 				iValue = (
 					getModifiedIntValue(
@@ -11352,7 +11352,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			{
 				//Calvitix try to limit impact of moves
 				iValue += iCombatValue;
-				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) * 0.5; //Only extra moves gives +50% bonus
+				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) / 2; //Only extra moves gives +50% bonus
 				break;
 			}
 			case UNITAI_MISSIONARY:
@@ -11426,20 +11426,20 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			case UNITAI_ATTACK_SEA:
 			{
 				iValue += iCombatValue;
-				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) * 0.5 ; //Calvitix 50% bonus per extra moves
+				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) / 2; //Calvitix 50% bonus per extra moves
 				iValue += kUnitInfo.getBombardRate() * 4;
 				break;
 			}
 			case UNITAI_RESERVE_SEA:
 			{
 				iValue += iCombatValue;
-				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) * 0.50;
+				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) / 2;
 				break;
 			}
 			case UNITAI_ESCORT_SEA:
 			{
 				iValue += iCombatValue;
-				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) * 0.25;
+				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) / 4;
 				iValue += kUnitInfo.getInterceptionProbability() * 3;
 				if (kUnitInfo.getNumSeeInvisibleTypes() > 0)
 				{
@@ -11495,14 +11495,14 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			case UNITAI_MISSILE_CARRIER_SEA:
 			{
 				iValue += iCombatValue;
-				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) * 0.25;
+				iValue += iCombatValue * (kUnitInfo.getMoves() - 1) /4 ;
 				iValue += (25 + iCombatValue) * (3 + (kUnitInfo.getCargoSpace()));
 				break;
 			}
 			case UNITAI_PIRATE_SEA:
 			{
 				iValue += iCombatValue;
-				iValue += (iCombatValue * (kUnitInfo.getMoves() - 1) * 0.5);
+				iValue += (iCombatValue * (kUnitInfo.getMoves() - 1) /2);
 				break;
 			}
 			case UNITAI_ATTACK_AIR:
@@ -11570,12 +11570,12 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 			{
 				const InvisibleTypes eVisibilityRequested = criteria ? criteria->m_eVisibility : NO_INVISIBLE;
 				iValue += iCombatValue;
-				iValue += (kUnitInfo.getMoves() - 1) * 300;
+				iValue += (kUnitInfo.getMoves() - 1) * 30 / 100;
 				if (eVisibilityRequested != NO_INVISIBLE)
 				{
 					if (GC.getGame().isOption(GAMEOPTION_COMBAT_HIDE_SEEK))
 					{
-						iValue *= kUnitInfo.getVisibilityIntensityType(eVisibilityRequested);
+						iValue += kUnitInfo.getVisibilityIntensityType(eVisibilityRequested);
 					}
 					else
 					{
@@ -11596,7 +11596,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 						const InvisibilityArray& array = kUnitInfo.getVisibilityIntensityTypes();
 						for (InvisibilityArray::const_iterator it = array.begin(); it != array.end(); ++it)
 						{
-							iValue = getModifiedIntValue(iValue, 10 * (*it).second);
+							iValue = getModifiedIntValue(iValue, 100 * (*it).second);
 						}
 					}
 					else
@@ -11611,7 +11611,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 				iValue += iCombatValue;
 				//obsolete - for every 10 pts of combat value, make each move pt count for 1 more than a base 1 each.
 				//Try 
-				iValue += (kUnitInfo.getMoves()-1) * iCombatValue * 0.20;
+				iValue += (kUnitInfo.getMoves()-1) * iCombatValue / 5;
 				//Combat weaknesses are very bad
 				for (int iI = 0; iI < GC.getNumTerrainInfos(); iI++)
 				{
@@ -11688,11 +11688,17 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 		}
 	}
 
-	if (gPlayerLogLevel > 2)
+	if (gPlayerLogLevel > 3) //Calvitix, added a level 4 for very consuming logs
 	{
 		const CvWString strUnitType = GC.getUnitInfo(eUnit).getType();
 		const CvWString strUnitAIType = GC.getUnitAIInfo(eUnitAI).getType();
-		logAiEvaluations(2, "AI Player %d evaluate Value for unit %S as type %S, combat value %d, moves %d, Calculated value %d", getID(), strUnitType.c_str(), strUnitAIType.c_str(), iCombatValue*100, kUnitInfo.getMoves(), iValue*100);
+
+		CvWString strCriteria = "None";
+		if (criteria != NULL)
+		{
+			strCriteria = criteria->getDescription();
+		}
+		logAiEvaluations(2, "AI Player %d evaluate Value for unit %S as type %S and criteria (%S), combat value %d, moves %d, Calculated value %d", getID(), strUnitType.c_str(), strUnitAIType.c_str(), strCriteria.c_str(), iCombatValue*100, kUnitInfo.getMoves(), iValue*100);
 	}
 
 
@@ -24889,7 +24895,7 @@ int CvPlayerAI::AI_getCitySitePriorityFactor(const CvPlot* pPlot) const
 void CvPlayerAI::AI_updateCitySites(int iMinFoundValueThreshold, int iMaxSites) const
 {
 	PROFILE_EXTRA_FUNC();
-	logAiEvaluations(2, "Player %d (%S) begin Update City Sites (min. value: %d)...", getID(), getCivilizationDescription(0), iMinFoundValueThreshold);
+	logAiEvaluations(1, "Player %d (%S) begin Update City Sites (min. value: %d)...", getID(), getCivilizationDescription(0), iMinFoundValueThreshold);
 	for (int iI = 0; iI < iMaxSites; iI++)
 	{
 		//Add a city to the list.
@@ -24912,7 +24918,7 @@ void CvPlayerAI::AI_updateCitySites(int iMinFoundValueThreshold, int iMaxSites) 
 					{
 						iBestFoundValue = iValue;
 						pBestFoundPlot = plotX;
-						logAiEvaluations(2, "  Potential best city site (%d, %d) found value is %d (player modified value to %d)", plotX->getX(), plotX->getY(), iFoundValue, iValue);
+						logAiEvaluations(1, "  Potential best city site (%d, %d) found value is %d (player modified value to %d)", plotX->getX(), plotX->getY(), iFoundValue, iValue);
 					}
 				}
 			}
@@ -24921,11 +24927,11 @@ void CvPlayerAI::AI_updateCitySites(int iMinFoundValueThreshold, int iMaxSites) 
 		{
 			break;
 		}
-		logAiEvaluations(2, "	Found City Site at (%d, %d)", pBestFoundPlot->getX(), pBestFoundPlot->getY());
+		logAiEvaluations(1, "	Found City Site at (%d, %d)", pBestFoundPlot->getX(), pBestFoundPlot->getY());
 		m_aiAICitySites.push_back(GC.getMap().plotNum(pBestFoundPlot->getX(), pBestFoundPlot->getY()));
 		AI_recalculateFoundValues(pBestFoundPlot->getX(), pBestFoundPlot->getY(), CITY_PLOTS_RADIUS, 2 * CITY_PLOTS_RADIUS);
 	}
-	logAiEvaluations(2, "Player %d (%S) end Update City Sites", getID(), getCivilizationDescription(0));
+	logAiEvaluations(1, "Player %d (%S) end Update City Sites", getID(), getCivilizationDescription(0));
 }
 
 void CvPlayerAI::calculateCitySites() const
@@ -31240,7 +31246,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 35);
+					iValue += (iTemp * 350);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31295,7 +31301,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 35);
+					iValue += (iTemp * 350); //Calvitix Test
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31413,7 +31419,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 15);
+					iValue += (iTemp * 150);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31444,7 +31450,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 15);
+					iValue += (iTemp * 150);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31475,7 +31481,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 15);
+					iValue += (iTemp * 150);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31506,7 +31512,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 8);
+					iValue += (iTemp * 80);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31537,7 +31543,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 8);
+					iValue += (iTemp * 80);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -31568,7 +31574,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 					eUnitAI == UNITAI_SEE_INVISIBLE_SEA ||
 					eUnitAI == UNITAI_PILLAGE_COUNTER)
 				{
-					iValue += (iTemp * 8);
+					iValue += (iTemp * 80);
 				}
 				else if (eUnitAI == UNITAI_COUNTER ||
 					eUnitAI == UNITAI_ANIMAL ||
@@ -32855,16 +32861,16 @@ int CvPlayerAI::AI_unitCombatValue(UnitCombatTypes eUnitCombat, UnitTypes eUnit,
 		if ((eUnitAI == UNITAI_SEE_INVISIBLE) ||
 			(eUnitAI == UNITAI_SEE_INVISIBLE_SEA))
 		{
-			iValue += (iTemp * 50);
+			iValue += (iTemp * 5);  //Calvitix origin 50
 		}
 		else if ((eUnitAI == UNITAI_EXPLORE_SEA) ||
 			(eUnitAI == UNITAI_EXPLORE))
 		{
-			iValue += (iTemp * 40);
+			iValue += (iTemp * 4);  //Calvitix origin 40
 		}
 		else if (eUnitAI == UNITAI_PIRATE_SEA)
 		{
-			iValue += (iTemp * 20);
+			iValue += (iTemp * 2); //Calvitix origin 20
 		}
 	}
 
@@ -32887,11 +32893,11 @@ int CvPlayerAI::AI_unitCombatValue(UnitCombatTypes eUnitCombat, UnitTypes eUnit,
 				(eUnitAI == UNITAI_ESCORT) ||
 				(eUnitAI == UNITAI_INFILTRATOR))
 		{
-			iValue += (iTemp * 40);
+			iValue += (iTemp * 20);  //40
 		}
 		else
 		{
-			iValue += (iTemp * 25);
+			iValue += (iTemp * 8);  //25
 		}
 	}
 

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -11836,7 +11836,7 @@ int CvPlayerAI::AI_neededWorkers(const CvArea* pArea) const
 	{
 		return 0;
 	}
-	iNeeded = std::max(iNeeded, 1 + iCities + intSqrt(iCities)); // max 1 + 1 workers per city in area + 1 worker per city squared in area.
+	iNeeded = std::min(iNeeded, 1 + iCities + intSqrt(iCities)); // max 1 + 1 workers per city in area + 1 worker per city squared in area.
 
 	if (gPlayerLogLevel > 2)
 	{

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -11575,7 +11575,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 				{
 					if (GC.getGame().isOption(GAMEOPTION_COMBAT_HIDE_SEEK))
 					{
-						iValue += kUnitInfo.getVisibilityIntensityType(eVisibilityRequested);
+						iValue *= kUnitInfo.getVisibilityIntensityType(eVisibilityRequested);
 					}
 					else
 					{
@@ -21592,10 +21592,8 @@ bool CvPlayerAI::AI_disbandUnit(int iExpThreshold)
 	{
 		if (gPlayerLogLevel >= 2)
 		{
-			CvWString szString;
-			getUnitAIString(szString, pBestUnit->AI_getUnitAIType());
-
-			logBBAI("	Player %d (%S) disbanding %S with UNITAI %S to save cash", getID(), getCivilizationDescription(0), pBestUnit->getName().GetCString(), szString.GetCString());
+			const CvWString szStringUnitAi = GC.getUnitAIInfo(pBestUnit->AI_getUnitAIType()).getType();
+			logBBAI("	Player %d (%S) disbanding %S with UNITAI %S to save cash", getID(), getCivilizationDescription(0), pBestUnit->getName().GetCString(), szStringUnitAi.GetCString());
 		}
 		pBestUnit->kill(false);
 		return true;
@@ -31730,8 +31728,12 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 	if (pUnit != NULL && iValue > 0 && !bForBuildUp)
 	{
 		//GC.getGame().logOOSSpecial(2,iValue, pUnit->getID());
-		iRandom = int(50) + (iValue / 10); //Calvitix introduce more Random for High Values
-		iRandom = GC.getGame().getSorenRandNum(iRandom, "AI Unit Promote");
+		int iRandomRange = (int(50) + (iValue / 10)); //Calvitix introduce more Random for High Values
+		iRandom = GC.getGame().getSorenRandNum(iRandomRange, "AI Unit Promote");
+		if (iValue > 75)
+		{ //to permit the lower of value with random
+			iRandom -= iRandomRange / 2;
+		}
 	}
 
 	if (pUnit != NULL && !bForBuildUp && gUnitLogLevel > 3)

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -11698,7 +11698,7 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 		{
 			strCriteria = criteria->getDescription();
 		}
-		logAiEvaluations(2, "AI Player %d evaluate Value for unit %S as type %S and criteria (%S), combat value %d, moves %d, Calculated value %d", getID(), strUnitType.c_str(), strUnitAIType.c_str(), strCriteria.c_str(), iCombatValue*100, kUnitInfo.getMoves(), iValue*100);
+		logAiEvaluations(3, "AI Player %d evaluate Value for unit %S as type %S and criteria (%S), combat value %d, moves %d, Calculated value %d", getID(), strUnitType.c_str(), strUnitAIType.c_str(), strCriteria.c_str(), iCombatValue*100, kUnitInfo.getMoves(), iValue*100);
 	}
 
 
@@ -28677,7 +28677,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 		if ((eUnitAI == UNITAI_SEE_INVISIBLE) ||
 			(eUnitAI == UNITAI_SEE_INVISIBLE_SEA))
 		{
-			iValue += (iTemp * 50);
+			iValue += (iTemp * 100); //50
 		}
 		else if ((eUnitAI == UNITAI_EXPLORE_SEA) ||
 			(eUnitAI == UNITAI_EXPLORE))
@@ -31726,12 +31726,28 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 	{
 		iValue = std::max(1, iValue);
 	}
-
+	int iRandom = 0;
 	if (pUnit != NULL && iValue > 0 && !bForBuildUp)
 	{
 		//GC.getGame().logOOSSpecial(2,iValue, pUnit->getID());
-		iValue += GC.getGame().getSorenRandNum(25, "AI Unit Promote");
+		iRandom = int(50) + (iValue / 10); //Calvitix introduce more Random for High Values
+		iRandom = GC.getGame().getSorenRandNum(iRandom, "AI Unit Promote");
 	}
+
+	if (pUnit != NULL && !bForBuildUp && gUnitLogLevel > 3)
+	{
+		CvWString StrunitAIType = GC.getUnitAIInfo(pUnit->AI_getUnitAIType()).getType();
+		logAiEvaluations(2, "	Player %S, PromotionEval for Unit %S of type %S - %S : Value : %d, Random %d", this->getPlayer, pUnit->getName(0).GetCString(), StrunitAIType.GetCString(), GC.getPromotionInfo(ePromotion).getDescription(), iValue, iRandom);
+	}
+	else if ((pUnit != NULL && bForBuildUp && gUnitLogLevel > 3))
+	{
+		CvWString StrunitAIType = GC.getUnitAIInfo(pUnit->AI_getUnitAIType()).getType();
+		logAiEvaluations(2, "	Player %S, BuildUpEval for Unit %S of type %S - %S : Value : %d, Random %d", this->getPlayer, pUnit->getName(0).GetCString(), StrunitAIType.GetCString(), GC.getPromotionInfo(ePromotion).getDescription(), iValue, iRandom);
+	}
+
+	iValue += iRandom;
+
+
 
 	return iValue;
 }

--- a/Sources/CvPlayerAI.h
+++ b/Sources/CvPlayerAI.h
@@ -458,6 +458,55 @@ public:
 
 	int AI_getUnitWeight(UnitTypes eUnit) const;
 	int AI_getUnitCombatWeight(UnitCombatTypes eUnitCombat) const;
+
+
+	/**
+	 * \brief Calculate the relative viability of a unit type for a given AI role.
+	 *
+	 * This function evaluates all units of the specified domain and determines
+	 * how strong the best unit of the requested AI type is compared to other
+	 * available units in the same domain.
+	 *
+	 * \param eUnitAI The Unit AI role to evaluate (e.g., UNITAI_ATTACK, UNITAI_CITY_DEFENSE).
+	 * \param eDomain The domain of units to consider (DOMAIN_LAND, DOMAIN_SEA, DOMAIN_AIR).
+	 *
+	 * \return An integer representing the relative strength of the best unit
+	 *         for the requested AI type compared to the strongest other unit
+	 *         in the same domain. The value is scaled by 100.
+	 *
+	 * \note
+	 * - Units are considered only if they are available to the player's team
+	 *   (weight > 0 or prerequisite tech known).
+	 * - Compares combat strength (`getCombat()`) of units.
+	 *
+	 * \see CvUnitInfo::getUnitAIType()
+	 * \see GET_TEAM()
+	 * \see CvPlayerAI::m_aiUnitWeights
+	 *
+	 * \dot
+	 * digraph AI_calculateUnitAIViability {
+	 *   rankdir=LR;
+	 *   node [shape=box, style=filled, color=lightblue];
+	 *   Start [label="Start"];
+	 *   ForEachUnit [label="For each unit in domain"];
+	 *   CheckAvailability [label="Check if player can use unit"];
+	 *   CheckUnitAI [label="Does unit match eUnitAI?"];
+	 *   UpdateBestAI [label="Update iBestUnitAIStrength"];
+	 *   UpdateBestOther [label="Update iBestOtherStrength"];
+	 *   ReturnValue [label="Return (100 * iBestUnitAIStrength) / iBestOtherStrength"];
+	 *
+	 *   Start -> ForEachUnit;
+	 *   ForEachUnit -> CheckAvailability;
+	 *   CheckAvailability -> CheckUnitAI [label="Yes"];
+	 *   CheckAvailability -> UpdateBestOther [label="No"];
+	 *   CheckUnitAI -> UpdateBestAI [label="Yes"];
+	 *   CheckUnitAI -> UpdateBestOther [label="No"];
+	 *   UpdateBestAI -> ForEachUnit;
+	 *   UpdateBestOther -> ForEachUnit;
+	 *   ForEachUnit -> ReturnValue [label="End loop"];
+	 * }
+	 * \enddot
+	 */
 	int AI_calculateUnitAIViability(UnitAITypes eUnitAI, DomainTypes eDomain) const;
 
 	void AI_updateBonusValue();

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -13469,8 +13469,13 @@ int CvPlot::countSeeInvisibleActive(PlayerTypes ePlayer, InvisibleTypes eVisible
 	{
 		const UnitAITypes eAIType = pLoopUnit->AI_getUnitAIType();
 		//MissionAITypes eMissionAI = pLoopUnit->getGroup()->AI_getMissionAIType();
-
-		if (eAIType == UNITAI_SEE_INVISIBLE || eAIType == UNITAI_SEE_INVISIBLE_SEA)
+		
+		if (eAIType == UNITAI_SEE_INVISIBLE || eAIType == UNITAI_SEE_INVISIBLE_SEA 
+			|| eAIType == UNITAI_PROPERTY_CONTROL || eAIType == UNITAI_CITY_DEFENSE
+			|| eAIType == UNITAI_HUNTER_ESCORT || eAIType == UNITAI_HUNTER
+			|| eAIType == UNITAI_PILLAGE_COUNTER || eAIType == UNITAI_INVESTIGATOR
+			|| eAIType == UNITAI_RESERVE || eAIType == UNITAI_COUNTER
+			|| eAIType == UNITAI_SPY || eAIType == UNITAI_CITY_COUNTER)
 		{
 			if (pLoopUnit->getOwner() == ePlayer)
 			{

--- a/Sources/CvSelectionGroup.cpp
+++ b/Sources/CvSelectionGroup.cpp
@@ -4491,7 +4491,7 @@ void CvSelectionGroup::setActivityType(ActivityTypes eNewValue, MissionTypes eSl
 							||	eSleepType == NO_MISSION
 						)
 					) pLoopUnit->setBuildUpType(NO_PROMOTIONLINE, eSleepType);
-
+					
 					pLoopUnit->setSleepType(pLoopUnit->isFortifyable() ? MISSION_FORTIFY : MISSION_SLEEP);
 				}
 			}

--- a/Sources/CvSelectionGroup.h
+++ b/Sources/CvSelectionGroup.h
@@ -331,7 +331,7 @@ public:
 	virtual void AI_noteSizeChange(int iChange, int iVolume) = 0;
 	virtual CvUnit* AI_getMissionAIUnit() const = 0;
 	virtual CvUnit* AI_ejectBestDefender(const CvPlot* pTargetPlot, bool allowAllDefenders = false) = 0;
-	virtual bool AI_hasBeneficialPropertyEffectForCity(const CvCity* pCity) const = 0;
+	virtual bool AI_hasBeneficialPropertyEffectForCity(const CvCity* pCity, PropertyTypes pProperty) const = 0;
 	virtual CvUnit* AI_ejectBestPropertyManipulator(const CvCity* pTargetCity) = 0;
 	virtual void AI_separateNonAI(UnitAITypes eUnitAI) = 0;
 	virtual void AI_separateAI(UnitAITypes eUnitAI) = 0;

--- a/Sources/CvSelectionGroupAI.cpp
+++ b/Sources/CvSelectionGroupAI.cpp
@@ -1200,12 +1200,12 @@ int CvSelectionGroupAI::AI_getGenericValueTimes100(UnitValueFlags eFlags) const
 	return iResult;
 }
 
-bool CvSelectionGroupAI::AI_hasBeneficialPropertyEffectForCity(const CvCity* pCity) const
+bool CvSelectionGroupAI::AI_hasBeneficialPropertyEffectForCity(const CvCity* pCity, PropertyTypes pProperty) const
 {
 	PROFILE_EXTRA_FUNC();
 	foreach_(const CvUnit* pLoopUnit, units())
 	{
-		if (pLoopUnit->AI_beneficialPropertyValueToCity(pCity, NO_PROPERTY) > 0)
+		if (pLoopUnit->AI_beneficialPropertyValueToCity(pCity, pProperty) > 0)
 		{
 			return true;
 		}

--- a/Sources/CvSelectionGroupAI.h
+++ b/Sources/CvSelectionGroupAI.h
@@ -67,7 +67,7 @@ public:
 	void AI_noteSizeChange(int iChange, int iVolume);
 	CvUnit* AI_findBestDefender(const CvPlot* pTargetPlot, bool allowAllDefenders, bool bConsiderPropertyValues = false) const;
 	CvUnit* AI_ejectBestDefender(const CvPlot* pTargetPlot, bool allowAllDefenders);
-	virtual bool AI_hasBeneficialPropertyEffectForCity(const CvCity* pCity) const;
+	virtual bool AI_hasBeneficialPropertyEffectForCity(const CvCity* pCity, PropertyTypes pProperty) const;
 	virtual CvUnit* AI_ejectBestPropertyManipulator(const CvCity* pTargetCity);
 	virtual int AI_getGenericValueTimes100(UnitValueFlags eFlags) const;
 

--- a/Sources/CvTeamAI.h
+++ b/Sources/CvTeamAI.h
@@ -26,6 +26,57 @@ public:
 	void AI_reset(bool bConstructor);
 
 	void AI_doTurnPre();
+
+	/**
+	 * \brief Perform post-turn AI actions for the team.
+	 *
+	 * This function is called at the end of the team's turn to update
+	 * strategic evaluations and possibly execute war actions.
+	 *
+	 * The sequence of operations is as follows:
+	 * 1. Update the team's worst enemy based on current game state.
+	 * 2. Update area strategies, without forcing updates on all areas.
+	 * 3. If the team is human-controlled, NPC, or a minor civilization, exit early.
+	 * 4. Execute war-related AI decisions if applicable.
+	 *
+	 * \note
+	 * - Calls `AI_updateWorstEnemy()` to refresh the enemy evaluation.
+	 * - Calls `AI_updateAreaStragies(false)` to update area-specific strategies.
+	 * - Calls `AI_doWar()` to carry out attacks or military moves for the team.
+	 *
+	 * \see CvTeamAI::AI_updateWorstEnemy()
+	 * \see CvTeamAI::AI_updateAreaStragies()
+	 * \see CvTeamAI::AI_doWar()
+	 *
+	 * \dot
+		digraph AI_doTurnPost {
+			rankdir=TB;  // vertical layout
+			bgcolor="#ffffff";  // white background
+
+			// Default node style
+			node [shape=box, style=filled, fontname="Arial", fontsize=10, color="#555555", fillcolor="#f9f9f9", penwidth=1.5];
+
+			// Default edge style
+			edge [color="#5555aa", penwidth=1.5, arrowsize=1];
+
+			// Nodes
+			Start [label="Start AI_doTurnPost", fillcolor="#cde8ff"];
+			UpdateWorstEnemy [label="AI_updateWorstEnemy()"];
+			UpdateAreaStrategies [label="AI_updateAreaStragies(false)"];
+			CheckHumanNPCMinor [label="isHuman() || isNPC() || isMinorCiv?", shape=diamond, fillcolor="#ffd7d7"];
+			ReturnIfHuman [label="Return (skip AI war)", fillcolor="#eeeeee"];
+			DoWar [label="AI_doWar()", fillcolor="#d7ffd7"];
+			End [label="End AI_doTurnPost", fillcolor="#cde8ff"];
+
+			// Flow
+			Start -> UpdateWorstEnemy -> UpdateAreaStrategies -> CheckHumanNPCMinor;
+			CheckHumanNPCMinor -> ReturnIfHuman [label="Yes"];
+			CheckHumanNPCMinor -> DoWar [label="No"];
+			ReturnIfHuman -> End;
+			DoWar -> End;
+		}
+	 * \enddot
+	 */
 	void AI_doTurnPost();
 
 	void AI_makeAssignWorkDirty();

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -36535,8 +36535,29 @@ void CvUnit::setBuildUpType(PromotionLineTypes ePromotionLine, MissionTypes eSle
 
 					if (iValue > iBestValue)
 					{
+						if (gUnitLogLevel > 3) //TO DO
+						{
+								const CvWString strUnitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
+								CvWString szDesc = GC.getPromotionInfo(ePromotion).getDescription();
+								//const CvWString strCriteria = criteria.GetDescription();
+
+								logAiEvaluations(2,"    %S find better Eval (%d > %d) to promote %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
+						}
 						iBestValue = iValue;
 						eAssignPromotionLine = ePotentialPromotionLine;
+
+
+					}
+					else
+					{
+						if (gUnitLogLevel > 3) //TO DO
+						{
+							const CvWString strUnitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
+							CvWString szDesc = GC.getPromotionInfo(ePromotion).getDescription();
+							//const CvWString strCriteria = criteria.GetDescription();
+
+							logAiEvaluations(2, "    %S will not choose that prom (%d <= %d) to promote %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
+						}
 					}
 				}
 			}

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -36539,9 +36539,8 @@ void CvUnit::setBuildUpType(PromotionLineTypes ePromotionLine, MissionTypes eSle
 						{
 								const CvWString strUnitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
 								CvWString szDesc = GC.getPromotionInfo(ePromotion).getDescription();
-								//const CvWString strCriteria = criteria.GetDescription();
-
-								logAiEvaluations(2,"    %S find better Eval (%d > %d) to promote %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
+								//const CvWString strCriteria = criteria.GetDescription();								
+								logAiEvaluations(2,"    %S find better Eval (%d > %d) to buildup %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
 						}
 						iBestValue = iValue;
 						eAssignPromotionLine = ePotentialPromotionLine;
@@ -36556,7 +36555,7 @@ void CvUnit::setBuildUpType(PromotionLineTypes ePromotionLine, MissionTypes eSle
 							CvWString szDesc = GC.getPromotionInfo(ePromotion).getDescription();
 							//const CvWString strCriteria = criteria.GetDescription();
 
-							logAiEvaluations(2, "    %S will not choose that prom (%d <= %d) to promote %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
+							logAiEvaluations(2, "    %S will not choose that prom (%d <= %d) to buildup %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
 						}
 					}
 				}

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -36540,7 +36540,7 @@ void CvUnit::setBuildUpType(PromotionLineTypes ePromotionLine, MissionTypes eSle
 								const CvWString strUnitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
 								CvWString szDesc = GC.getPromotionInfo(ePromotion).getDescription();
 								//const CvWString strCriteria = criteria.GetDescription();								
-								logAiEvaluations(2,"    %S find better Eval (%d > %d) to buildup %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
+								logAiEvaluations(4,"    %S find better Eval (%d > %d) to buildup %S with %S, unit AI %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), iValue, iBestValue, getName(0).GetCString(), szDesc.GetCString(), strUnitAIType.GetCString());
 						}
 						iBestValue = iValue;
 						eAssignPromotionLine = ePotentialPromotionLine;

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -29493,7 +29493,7 @@ bool CvUnitAI::AI_establishStackSeeInvisibleCoverage()
 
 						if (gUnitLogLevel > 2)
 						{
-							logBBAI("	%S (%d) at (%d,%d) [stack size %d] requests See Invisible Unit at priority %d", GET_PLAYER(getOwner()).getCivilizationDescription(0), getID(), getX(), getY(), getGroup()->getNumUnits(), HIGH_PRIORITY_ESCORT_PRIORITY);
+							logBBAI("	%S (%d) at (%d,%d) [stack size %d] requests UNITAI_SEE_INVISIBLE Unit at priority %d", GET_PLAYER(getOwner()).getCivilizationDescription(0), getID(), getX(), getY(), getGroup()->getNumUnits(), HIGH_PRIORITY_ESCORT_PRIORITY);
 						}
 
 						getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, MISSIONAI_WAIT_FOR_SEE_INVISIBLE);
@@ -29523,7 +29523,7 @@ bool CvUnitAI::AI_establishStackSeeInvisibleCoverage()
 
 						if (gUnitLogLevel > 2)
 						{
-							logBBAI("	%S (%d) at (%d,%d) [stack size %d] requests See Invisible Sea Unit at priority %d", GET_PLAYER(getOwner()).getCivilizationDescription(0), getID(), getX(), getY(), getGroup()->getNumUnits(), HIGH_PRIORITY_ESCORT_PRIORITY);
+							logBBAI("	%S (%d) at (%d,%d) [stack size %d] requests UNITAI_SEE_INVISIBLE Sea Unit at priority %d", GET_PLAYER(getOwner()).getCivilizationDescription(0), getID(), getX(), getY(), getGroup()->getNumUnits(), HIGH_PRIORITY_ESCORT_PRIORITY);
 						}
 
 						getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, MISSIONAI_WAIT_FOR_SEE_INVISIBLE);

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -28745,7 +28745,7 @@ namespace {
 			int iResponders = player.AI_plotTargetMissionAIs(city->plot(), MISSIONAI_PROPERTY_CONTROL_RESPONSE, NULL, 0);
 			int iExisting = player.AI_plotTargetMissionAIs(city->plot(), MISSIONAI_PROPERTY_CONTROL_MAINTAIN, NULL, 0);
 
-			if (iResponders > 0)
+			if (iResponders > 0 || iExisting > 0)
 			{
 				iValue /= (iResponders+iExisting);
 			}

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -859,9 +859,14 @@ bool CvUnitAI::AI_promote()
 	{
 		if (gUnitLogLevel > 2)
 		{
-			CvWString szString;
-			getUnitAIString(szString, AI_getUnitAIType());
+			CvWString StrunitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
+			CvWString StrUnitName = m_szName;
+			if (StrUnitName.length() == 0)
+			{
+				StrUnitName = getName(0).GetCString();
+			}
 			logBBAI("	%S's %S chooses promotion %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), getName(0).GetCString(), GC.getPromotionInfo(eBestPromotion).getDescription());
+			logAiEvaluations(2,"	Player %S Unit %S of type %S - chooses promotion %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), StrUnitName.GetCString(), StrunitAIType.GetCString(), GC.getPromotionInfo(eBestPromotion).getDescription());
 		}
 
 		if (promote(eBestPromotion, -1))

--- a/Sources/CvUnitSelectionCriteria.cpp
+++ b/Sources/CvUnitSelectionCriteria.cpp
@@ -1,0 +1,72 @@
+﻿//------------------------------------------------------------------------------------------------
+//
+//  FILE:    CvUnitSelectionCriteria.pp
+//
+//  PURPOSE: Unit ordering criteria
+//
+//------------------------------------------------------------------------------------------------
+
+#include "CvEnums.h"
+#include "CvString.h"
+#include "CvGlobals.h"
+#include "CvInfos.h"
+#include "CvUnitSelectionCriteria.h"
+
+
+	CvString CvUnitSelectionCriteria::getDescription() const
+	{
+		CvWStringBuffer buffer;
+
+		// UnitAI
+		if (m_eUnitAI != NO_UNITAI)
+		{
+			buffer.append(CvWString::format(L"UnitAI=%s; ",
+				GC.getUnitAIInfo(m_eUnitAI).getDescription()));
+		}
+
+		// Advisor
+		if (m_eIgnoreAdvisor != NO_ADVISOR)
+		{
+			buffer.append(CvWString::format(L"IgnoreAdvisor=%s; ",
+				GC.getAdvisorInfo(m_eIgnoreAdvisor).getDescription()));
+		}
+
+		// Heal combat type
+		if (m_eHealUnitCombat != NO_UNITCOMBAT)
+		{
+			buffer.append(CvWString::format(L"HealUnitCombat=%s; ",
+				GC.getUnitCombatInfo(m_eHealUnitCombat).getDescription()));
+		}
+
+		// Property
+		if (m_eProperty != NO_PROPERTY)
+		{
+			buffer.append(CvWString::format(L"Property=%s %s; ",
+				m_bPropertyBeneficial ? L"improver" : L"worsener",
+				GC.getPropertyInfo(m_eProperty).getDescription()));
+		}
+
+		// Visibility
+		if (m_eVisibility != NO_INVISIBLE)
+		{
+			buffer.append(CvWString::format(L"Visibility=%s; ",
+				GC.getInvisibleInfo(m_eVisibility).getDescription()));
+		}
+
+		// Flags booléens
+		if (m_bIgnoreNotUnitAIs)   buffer.append(L"IgnoreNotUnitAIs; ");
+		if (m_bIgnoreGrowth)       buffer.append(L"IgnoreGrowth; ");
+		if (!m_bPropertyBeneficial) buffer.append(L"PropertyNotBeneficial; ");
+		if (m_bNoNegativeProperties) buffer.append(L"NoNegativeProperties; ");
+		if (m_bIsHealer)           buffer.append(L"Healer; ");
+		if (m_bIsCommander)        buffer.append(L"Commander; ");
+		if (m_bIsCommodore)        buffer.append(L"Commodore; ");
+
+		// Si rien n'a été rempli → retour vide
+		if (buffer.isEmpty())
+			return CvString("EmptyCriteria");
+
+		return CvString(buffer.getCString());
+	}
+
+

--- a/Sources/CvUnitSelectionCriteria.h
+++ b/Sources/CvUnitSelectionCriteria.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifndef CIV4_UNIT_SELECTION_CRITERIA_H
 #define CIV4_UNIT_SELECTION_CRITERIA_H
@@ -66,20 +66,7 @@ public:
 	CvUnitSelectionCriteria& IsCommander(bool IsCommander) { m_bIsCommander = IsCommander; return *this; }
 	CvUnitSelectionCriteria& IsCommodore(bool IsCommodore) { m_bIsCommodore = IsCommodore; return *this; }
 
-	CvString getDescription() const
-	{
-		if (m_eProperty != NO_PROPERTY)
-		{
-			return (
-				CvString::format(
-					"Property %s for %S",
-					m_bPropertyBeneficial ? "improver" : "worsener",
-					GC.getPropertyInfo(m_eProperty).getDescription()
-				)
-			);
-		}
-		return CvString("");
-	}
+	CvString getDescription() const;
 
 	int getHash() const
 	{


### PR DESCRIPTION
* Reduce the reactivity if SEE_INVISIBLE needed (Unit is ordered only by 30% of time)
=> As that check is done every turn for every visibility

* All Defensive/Counter Units in Town are evaluated to check the Visibility Intensity (not only the SEE_INVISIBLE in countSeeInvisibleActive
=> a LE or Dog that is assigned to City_Defense or else (Not See_Invisibility), if it has Visibility promotion, will be count as active, and no new unit will be ordered.

* Promotion Weight Value of VisibilityChange for SEE_INVISIBLE x2 and for VisibilityChangeRange x10
   (value can be adjusted later). To ensure that the VisibilityChange promotions are chosen

Not specific to Fix :
* Introduce more RNG (50+10% Value) for promotion Evaluation (was 25) => to encourage diversity in promotions.
+ Add a 4th level of log, for Log that generate a lot of trace. If _DEBUG, Level of Log is set to 4.
+ Add a lot of AIEvaluation Logs (Promotion Eval, See_Invisiblecoverage,...
+ Add a criteriaToString description to help log